### PR TITLE
Removes unnecessary props from app-specific date picker component

### DIFF
--- a/src/components/DatePickerModal.js
+++ b/src/components/DatePickerModal.js
@@ -16,11 +16,13 @@ export default function MyDatePickerModal({
     }
   }
 
+  // TODO: saveLabel doesn't seem to take effect
   return (
     <DatePickerModal
       visible={visible}
       locale="en"
       mode="single"
+      saveLabel="Defer"
       date={date}
       onConfirm={handleConfirm}
       onDismiss={onDismiss}

--- a/src/screens/TodoDetail/DetailDisplay/Actions/Defer.js
+++ b/src/screens/TodoDetail/DetailDisplay/Actions/Defer.js
@@ -97,8 +97,6 @@ export default function Defer({todo, onUpdate, onCancel, onComplete}) {
       </View>
       <DatePickerModal
         visible={isDeferredUntilModalOpen}
-        mode="single"
-        saveLabel="Defer"
         date={deferredUntil ? new Date(deferredUntil) : null}
         onConfirm={dayEnd => handleDeferUntil(dayEnd)}
         onDismiss={() => setIsDeferredUntilModalOpen(false)}

--- a/src/screens/TodoDetail/DetailForm.js
+++ b/src/screens/TodoDetail/DetailForm.js
@@ -97,8 +97,6 @@ export default function DetailForm({todo, onSave, onCancel}) {
         </Button>
         <DatePickerModal
           visible={isDeferredUntilModalOpen}
-          locale="en"
-          mode="single"
           date={deferredUntil ? new Date(deferredUntil) : null}
           onConfirm={handleChangeDeferredUntil}
           onDismiss={() => setIsDeferredUntilModalOpen(false)}


### PR DESCRIPTION
Also identified a prop that doesn't seem to be correctly used by `react-native-paper-dates`: `saveLabel`