### PR TITLE
Remove code no longer necessary for sidebar collapse

### DIFF
--- a/src/Navigation.js
+++ b/src/Navigation.js
@@ -281,17 +281,8 @@ const getDrawerTypeForBreakpoint = breakpoint =>
 
 function NavigationContents() {
   const {isLoggedIn} = useToken();
-  const navigation = useNavigation();
   const breakpoint = useBreakpoint();
-  const drawerTypeForBreakpoint = getDrawerTypeForBreakpoint(breakpoint);
-  const [drawerType, setDrawerType] = useState(drawerTypeForBreakpoint);
-
-  useEffect(() => {
-    navigation.dispatch(DrawerActions.closeDrawer());
-    setTimeout(() => {
-      setDrawerType(drawerTypeForBreakpoint);
-    }, 500);
-  }, [drawerTypeForBreakpoint, navigation]);
+  const drawerType = getDrawerTypeForBreakpoint(breakpoint);
 
   // IMPORTANT: NavigationContainer must not rerender too often because
   // it calls the history API, and Safari and Firefox place limits on


### PR DESCRIPTION
Previously, if you went to small, expanded the sidebar, then went to large then back to small, there would be extra space the width of the sidebar. Now (probably in a React Navigation update), the library properly handles changing the type of the sidebar to and from permanent when it's set to visible.