### PR TITLE
Remove react-test-renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-import": "~2.25.4",
     "jest": "^26.6.3",
-    "jest-expo": "^44.0.0",
-    "react-test-renderer": "^17.0.2"
+    "jest-expo": "^44.0.0"
   },
   "jest": {
     "preset": "jest-expo",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7872,7 +7872,7 @@ react-shallow-renderer@^16.13.1:
     object-assign "^4.1.1"
     react-is "^16.12.0 || ^17.0.0"
 
-react-test-renderer@^17.0.2, react-test-renderer@~17.0.1:
+react-test-renderer@~17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-17.0.2.tgz#4cd4ae5ef1ad5670fc0ef776e8cc7e1231d9866c"
   integrity sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==


### PR DESCRIPTION
Some instructions said it was needed, but nothing seems to fail without it