### PR TITLE
Ignore expo-dev-client and @expo/metro-runtime in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,9 @@ updates:
       - dependency-name: "babel-core"
       - dependency-name: "babel-jest"
       # - dependency-name: "expo" # commented to get notification
+      - dependency-name: "@expo/metro-runtime"
       - dependency-name: "expo-constants"
+      - dependency-name: "expo-dev-client"
       - dependency-name: "expo-linking"
       - dependency-name: "expo-secure-store"
       - dependency-name: "expo-splash-screen"


### PR DESCRIPTION
## Summary
- Adds `expo-dev-client` and `@expo/metro-runtime` to the Dependabot ignore list so they're updated manually alongside Expo SDK upgrades rather than independently
- Closes open Dependabot PRs #630 and #631 once merged (they should be closed manually)

## Test plan
- [ ] Verify Dependabot does not re-open PRs for these two packages on the next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)