### PR TITLE
Bump eslint-plugin-cypress from 4.3.0 to 5.4.0

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,6 @@
 const {defineConfig} = require('eslint/config');
 const expoConfig = require('eslint-config-expo/flat');
-const cypressPlugin = require('eslint-plugin-cypress/flat');
+const cypressPlugin = require('eslint-plugin-cypress');
 const jestPlugin = require('eslint-plugin-jest');
 const testingLibraryPlugin = require('eslint-plugin-testing-library');
 const globals = require('globals');

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "cypress": "^15.11.0",
     "eslint": "^9.39.4",
     "eslint-config-expo": "~55.0.0",
-    "eslint-plugin-cypress": "^4.3.0",
+    "eslint-plugin-cypress": "^5.4.0",
     "eslint-plugin-ft-flow": "^3.0.11",
     "eslint-plugin-import": "~2.32.0",
     "eslint-plugin-testing-library": "^7.16.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5176,12 +5176,12 @@ eslint-module-utils@^2.12.1, eslint-module-utils@^2.8.1:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-cypress@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-4.3.0.tgz#fce3c67c836541cb652c653f5e33088c8926a988"
-  integrity sha512-CgS/S940MJlT8jtnWGKI0LvZQBGb/BB0QCpgBOxFMM/Z6znD+PZUwBhCTwHKN2GEr5AOny3xB92an0QfzBGooQ==
+eslint-plugin-cypress@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-5.4.0.tgz#548ec5e249ee3078f8859b74e295e65e7159cf43"
+  integrity sha512-XAQYuzMpLWJdFRQorPO3GDx4XHqI362qr1/XIp0N6SNTAa8lyzmpTA26qNRc99I53NnqX9l0SHwbHXX7TAKIkg==
   dependencies:
-    globals "^15.15.0"
+    globals "^17.3.0"
 
 eslint-plugin-eslint-comments@^3.2.0:
   version "3.2.0"
@@ -6204,15 +6204,15 @@ globals@^14.0.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-14.0.0.tgz#898d7413c29babcf6bafe56fcadded858ada724e"
   integrity sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==
 
-globals@^15.15.0:
-  version "15.15.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-15.15.0.tgz#7c4761299d41c32b075715a4ce1ede7897ff72a8"
-  integrity sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==
-
 globals@^16.0.0:
   version "16.1.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-16.1.0.tgz#ee6ab147d41c64e9f2beaaaf66572d18df8e1e60"
   integrity sha512-aibexHNbb/jiUSObBgpHLj+sIuUmJnYcgXBlrfsiDZ9rt4aF2TFRbyLgZ2iFQuVZ1K5Mx3FVkbKRSgKrbK3K2g==
+
+globals@^17.3.0:
+  version "17.6.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-17.6.0.tgz#0f0be018d5cca8690e6375ead1f65c4bb96191fc"
+  integrity sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==
 
 globalthis@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
## Summary
- Second of three stepped PRs to replace the failed direct jump in #638 (3.6.0 → 6.4.1).
- Bumps `eslint-plugin-cypress` from 4.3.0 to 5.4.0 (latest 5.x).
- v5 drops the `eslint-plugin-cypress/flat` subpath export — the flat config is now the package's default export. Updated `eslint.config.js` accordingly; `.configs.globals` is unchanged.

## Test plan
- [x] `yarn install` clean
- [x] `yarn lint` — 0 errors (3 pre-existing warnings)
- [x] `yarn test --watchAll=false` — all suites pass
- [ ] CI js-checks pass
- [ ] CI cypress pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)