### PR TITLE
Bump eslint-plugin-cypress from 5.4.0 to 6.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "cypress": "^15.11.0",
     "eslint": "^9.39.4",
     "eslint-config-expo": "~55.0.0",
-    "eslint-plugin-cypress": "^5.4.0",
+    "eslint-plugin-cypress": "^6.4.1",
     "eslint-plugin-ft-flow": "^3.0.11",
     "eslint-plugin-import": "~2.32.0",
     "eslint-plugin-testing-library": "^7.16.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5176,12 +5176,12 @@ eslint-module-utils@^2.12.1, eslint-module-utils@^2.8.1:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-cypress@^5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-5.4.0.tgz#548ec5e249ee3078f8859b74e295e65e7159cf43"
-  integrity sha512-XAQYuzMpLWJdFRQorPO3GDx4XHqI362qr1/XIp0N6SNTAa8lyzmpTA26qNRc99I53NnqX9l0SHwbHXX7TAKIkg==
+eslint-plugin-cypress@^6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-6.4.1.tgz#2aa64e5a2dcc56b8b916fdf8398a81b31a61c462"
+  integrity sha512-8mnfR3q0Lr41Fu9SYZGeZ5nbSBgtS44+bbtSs7k0KvfoQ2pPmK43IvaTP6FGTfwBTN6S7w027CpqjrLAd65AYA==
   dependencies:
-    globals "^17.3.0"
+    globals "^17.6.0"
 
 eslint-plugin-eslint-comments@^3.2.0:
   version "3.2.0"
@@ -6209,7 +6209,7 @@ globals@^16.0.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-16.1.0.tgz#ee6ab147d41c64e9f2beaaaf66572d18df8e1e60"
   integrity sha512-aibexHNbb/jiUSObBgpHLj+sIuUmJnYcgXBlrfsiDZ9rt4aF2TFRbyLgZ2iFQuVZ1K5Mx3FVkbKRSgKrbK3K2g==
 
-globals@^17.3.0:
+globals@^17.6.0:
   version "17.6.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-17.6.0.tgz#0f0be018d5cca8690e6375ead1f65c4bb96191fc"
   integrity sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==


### PR DESCRIPTION
## Summary
- Final of three stepped PRs replacing the failed direct jump in #638 (3.6.0 → 6.4.1).
- Bumps `eslint-plugin-cypress` from 5.4.0 to 6.4.1 (latest).
- No config change needed — the v5 export shape (default flat config exposing `.configs.globals`) is unchanged in v6.
- Once this merges, #638 can be closed.

## Test plan
- [x] `yarn install` clean
- [x] `yarn lint` — 0 errors (3 pre-existing warnings)
- [x] `yarn test --watchAll=false` — all suites pass
- [ ] CI js-checks pass
- [ ] CI cypress pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)