### PR TITLE
Use ubuntu-latest for CI runners

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   cypress:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/js-checks.yml
+++ b/.github/workflows/js-checks.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   js-checks:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Updates the CI workflows to run on `ubuntu-latest` (currently Ubuntu 24.04) instead of the pinned `ubuntu-22.04`.

## Changes
- `cypress.yml`: `ubuntu-22.04` → `ubuntu-latest`
- `js-checks.yml`: `ubuntu-22.04` → `ubuntu-latest`

`deploy.yml` already used `ubuntu-latest`, so all workflows are now consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)