### PR TITLE
Bump brace-expansion to patched versions on all three major lines

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3634,24 +3634,24 @@ bplist-parser@^0.3.1:
     big-integer "1.6.x"
 
 brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
-  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.4.tgz#589dab11c0018d0366be64cd8bf12c8dbecc8326"
+  integrity sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==
   dependencies:
     balanced-match "^1.0.0"
 
 brace-expansion@^5.0.2:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.4.tgz#614daaecd0a688f660bbbc909a8748c3d80d4336"
-  integrity sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.9.tgz#7c72438809b5fa5babf54199a1f1c281a6984fcf"
+  integrity sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
Addresses CVE-2026-13149 and the other open brace-expansion advisories.

## Approach

`brace-expansion` resolves at **three major lines** in this tree, each pulled in by a different `minimatch` major. The existing semver ranges already permit the patched releases, so this just refreshes the lockfile entries in place — **no `package.json` change and no `resolutions` override**.

| Consumer | Range | Before | After |
|---|---|---|---|
| `minimatch@3.x` | `^1.1.7` | 1.1.11 | **1.1.18** |
| `minimatch@9.x` | `^2.0.1` | 2.0.1 | **2.1.4** |
| `minimatch@10.x` | `^5.0.2` | 5.0.4 | **5.0.9** |

Keeping each line on its own major track matters: brace-expansion 4.x+ changed its export shape, so a blanket resolution forcing everything onto a 5.x version would break what `minimatch@3.x` consumes. That was the defect in #661.

Diff is 9 lines in `yarn.lock`, nothing else.

## Coverage

Bumping to the head of each line clears all 12 brace-expansion Dependabot alerts, not just the one originally reported:

- **CVE-2026-13149** (high) — needed 1.1.16 / 2.1.2 / 5.0.7
- **CVE-2026-14257** (high) — needed 1.1.17 / 2.1.3 / 5.0.8. Newer than #661's target; that PR's 5.0.7 pin would not have fixed it.
- **CVE-2026-45149** (medium) — needed 5.0.6
- **CVE-2026-33750** (medium) — needed 1.1.13 / 2.0.3 / 5.0.5
- **CVE-2025-5889** (low) — needed 1.1.12 / 2.0.2

## Verification

- `yarn test` — 20 suites / 109 tests passed, 0 FAIL, identical to a baseline captured on clean `main` beforehand.
- `yarn lint` — passes (one pre-existing `no-disabled-tests` warning).
- `yarn format:check` — passes, 191 files.
- Functional smoke test: `minimatch@3.x` still matches correctly; 50 consecutive empty brace groups expand in 1 ms, and `'{a,b}'.repeat(1500)` returns 2666 bounded results in 328 ms rather than an uncatchable OOM crash.

Note: `yarn test` exits 1 both before and after this change — jest scans the locally-generated, gitignored `ios/Pods` tree and reports 9 obsolete snapshots. Pre-existing and not visible in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
